### PR TITLE
compare on payload, not on full L2 data

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -379,7 +379,7 @@ fn layer2() {
                     if i == 10_000 {
                         panic!("layer2: did not find matching packet after 10_000 iterations");
                     }
-                    if EthernetPacket::new(&packet[..]).unwrap() == eh {
+                    if EthernetPacket::new(&packet[..]).unwrap().payload() == eh.payload() {
                         return;
                     }
                     i += 1;


### PR DESCRIPTION
We can't rely on L2 headers to be equal.

On OSX in lo0 ethetype was received as 0x0. I cannot argue it's incorrect to do
so, or incorrect not to do so. I can see why either approach may make sense,

and it's best if we don't rely on either.
